### PR TITLE
Update utc_datetime_from_string to be faster (strptime is slow)

### DIFF
--- a/src/bdrocfl/ocfl.py
+++ b/src/bdrocfl/ocfl.py
@@ -90,11 +90,13 @@ def _micro_seconds_from_micro_str(micro_str):
 
 def utc_datetime_from_string(date_string):
     try:
+        #fromisoformat is very fast - try this first
         dt = datetime.fromisoformat(date_string.replace('Z', '+00:00'))
         if not dt.tzinfo:
             raise DateTimeError(f'datetime must have timezone info: {date_string}')
         return dt
     except ValueError:
+        #if fromisoformat failed, fall back to this
         try:
             remaining_date_string = date_string[19:]
             year = int(date_string[0:4])

--- a/src/bdrocfl/ocfl.py
+++ b/src/bdrocfl/ocfl.py
@@ -89,34 +89,66 @@ def _micro_seconds_from_micro_str(micro_str):
 
 
 def utc_datetime_from_string_custom(date_string):
-    year, month, day = [int(i) for i in date_string[0:10].split('-')]
-    hours, minutes, seconds = [int(i) for i in date_string[11:19].split(':')]
-    micro_seconds = 0
-    tzinfo = None
-    remaining_date_string = date_string[19:]
-    if remaining_date_string.startswith('.'): #we have microseconds
-        if remaining_date_string.endswith('Z'):
-            tzinfo = timezone.utc
-            micro_str = remaining_date_string[1:-1]
-            micro_seconds = _micro_seconds_from_micro_str(micro_str)
-        elif '+' in remaining_date_string:
-            micro_str, tz_str = remaining_date_string.split('+')
-            micro_str = micro_str[1:]
-            micro_seconds = _micro_seconds_from_micro_str(micro_str)
-            tz_hours, tz_minutes = [int(i) for i in tz_str.split(':')]
-            tzinfo = timezone(timedelta(hours=tz_hours, minutes=tz_minutes))
-        elif '-' in remaining_date_string:
-            micro_str, tz_str = remaining_date_string.split('-')
-            micro_str = micro_str[1:]
-            micro_seconds = _micro_seconds_from_micro_str(micro_str)
-            tz_hours, tz_minutes = [int(i) for i in tz_str.split(':')]
-            tzinfo = timezone(timedelta(hours=tz_hours, minutes=tz_minutes) * -1)
-    else: #no microseconds
-        if remaining_date_string == 'Z':
-            tzinfo = timezone.utc
-    if not tzinfo:
-        raise DateTimeError(f'datetime must have timezone info: {date_string}')
-    return datetime(year, month, day, hours, minutes, seconds, micro_seconds, tzinfo).astimezone(timezone.utc)
+    try:
+        dt = datetime.fromisoformat(date_string.replace('Z', '+00:00'))
+        if not dt.tzinfo:
+            raise DateTimeError(f'datetime must have timezone info: {date_string}')
+        return dt
+    except ValueError:
+        try:
+            remaining_date_string = date_string[19:]
+            year = int(date_string[0:4])
+            month = int(date_string[5:7])
+            day = int(date_string[8:10])
+            hours = int(date_string[11:13])
+            minutes = int(date_string[14:16])
+            seconds = int(date_string[17:19])
+            micro_seconds = 0
+            tzinfo = None
+            if remaining_date_string[0] == '.': #we have microseconds
+                if remaining_date_string[-1] == 'Z':
+                    tzinfo = timezone.utc
+                    micro_str = remaining_date_string[1:-1]
+                    micro_seconds = _micro_seconds_from_micro_str(micro_str)
+                    return datetime(year, month, day, hours, minutes, seconds, micro_seconds, tzinfo)
+                elif '+' in remaining_date_string:
+                    micro_str, tz_str = remaining_date_string.split('+')
+                    micro_str = micro_str[1:]
+                    micro_seconds = _micro_seconds_from_micro_str(micro_str)
+                    tz_hours, tz_minutes = [int(i) for i in tz_str.split(':')]
+                    tzinfo = timezone(timedelta(hours=tz_hours, minutes=tz_minutes))
+                elif '-' in remaining_date_string:
+                    micro_str, tz_str = remaining_date_string.split('-')
+                    micro_str = micro_str[1:]
+                    micro_seconds = _micro_seconds_from_micro_str(micro_str)
+                    tz_hours, tz_minutes = [int(i) for i in tz_str.split(':')]
+                    tzinfo = timezone(timedelta(hours=tz_hours, minutes=tz_minutes) * -1)
+                else:
+                    raise DateTimeError(f'error parsing {date_string}')
+            else: #no microseconds
+                if remaining_date_string == 'Z':
+                    tzinfo = timezone.utc
+                elif remaining_date_string.startswith('+'):
+                    tz_str = remaining_date_string[1:]
+                    tz_hours, tz_minutes = [int(i) for i in tz_str.split(':')]
+                    tzinfo = timezone(timedelta(hours=tz_hours, minutes=tz_minutes))
+                elif remaining_date_string.startswith('-'):
+                    tz_str = remaining_date_string[1:]
+                    tz_hours, tz_minutes = [int(i) for i in tz_str.split(':')]
+                    tzinfo = timezone(timedelta(hours=tz_hours, minutes=tz_minutes) * -1)
+                else:
+                    raise DateTimeError(f'error parsing {date_string}')
+            dt = datetime(year, month, day, hours, minutes, seconds, micro_seconds, tzinfo)
+            if not dt.tzinfo:
+                raise DateTimeError(f'datetime must have timezone info: {date_string}')
+            if dt.tzinfo == timezone.utc:
+                return dt
+            else:
+                return dt.astimezone(timezone.utc)
+        except DateTimeError:
+            raise
+        except Exception:
+            raise DateTimeError(f'error parsing {datestring}')
 
 
 def utc_datetime_from_string_isoformat(s):

--- a/src/bdrocfl/ocfl.py
+++ b/src/bdrocfl/ocfl.py
@@ -88,7 +88,7 @@ def _micro_seconds_from_micro_str(micro_str):
     return micro_seconds
 
 
-def utc_datetime_from_string_custom(date_string):
+def utc_datetime_from_string(date_string):
     try:
         dt = datetime.fromisoformat(date_string.replace('Z', '+00:00'))
         if not dt.tzinfo:
@@ -151,34 +151,6 @@ def utc_datetime_from_string_custom(date_string):
             raise DateTimeError(f'error parsing {datestring}')
 
 
-def utc_datetime_from_string_isoformat(s):
-    try:
-        dt = datetime.fromisoformat(s.replace('Z', '+00:00'))
-        if not dt.tzinfo:
-            raise DateTimeError(f'datetime must have timezone info: {s}')
-        return dt
-    except ValueError:
-        try:
-            dt = datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%f%z')
-        except ValueError:
-            try:
-                dt = datetime.strptime(s, '%Y-%m-%dT%H:%M:%S%z')
-            except ValueError:
-                raise DateTimeError(f'unrecognized datetime format: {s}')
-        return dt.astimezone(tz=timezone.utc)
-
-
-def utc_datetime_from_string(s):
-    try:
-        dt = datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%f%z')
-    except ValueError:
-        try:
-            dt = datetime.strptime(s, '%Y-%m-%dT%H:%M:%S%z')
-        except ValueError:
-            raise DateTimeError(f'unrecognized datetime format: {s}')
-    return dt.astimezone(tz=timezone.utc)
-
-
 class Object:
 
     def __init__(self, pid, fallback_to_version_directory=True):
@@ -234,7 +206,7 @@ class Object:
             for filepath in filepaths:
                 if filepath not in info:
                     file_info = {
-                            'last_modified': utc_datetime_from_string_custom(self._inventory['versions'][self.head_version]['created']),
+                            'last_modified': utc_datetime_from_string(self._inventory['versions'][self.head_version]['created']),
                             'checksum': checksum,
                             'checksum_type': 'SHA-512',
                             'state': 'A',
@@ -259,7 +231,7 @@ class Object:
                     if filepath in info:
                         files_in_this_version.add(filepath)
                         if checksum == info[filepath]['checksum'] and not file_handled_mapping[filepath]:
-                            info[filepath]['last_modified'] = utc_datetime_from_string_custom(self._inventory['versions'][version_num]['created'])
+                            info[filepath]['last_modified'] = utc_datetime_from_string(self._inventory['versions'][version_num]['created'])
             #if there are any files in the head version, that aren't in this version, mark that we shouldn't update their time anymore
             for filepath in file_handled_mapping:
                 if filepath not in files_in_this_version:
@@ -268,11 +240,11 @@ class Object:
 
     @property
     def created(self):
-        return utc_datetime_from_string_custom(self._inventory['versions']['v1']['created'])
+        return utc_datetime_from_string(self._inventory['versions']['v1']['created'])
 
     @property
     def last_modified(self):
-        return utc_datetime_from_string_custom(self._inventory['versions'][self.head_version]['created'])
+        return utc_datetime_from_string(self._inventory['versions'][self.head_version]['created'])
 
     def get_path_to_file(self, filename, version=None):
         if not version:

--- a/src/bdrocfl/ocfl.py
+++ b/src/bdrocfl/ocfl.py
@@ -202,7 +202,7 @@ class Object:
             for filepath in filepaths:
                 if filepath not in info:
                     file_info = {
-                            'last_modified': utc_datetime_from_string(self._inventory['versions'][self.head_version]['created']),
+                            'last_modified': utc_datetime_from_string_custom(self._inventory['versions'][self.head_version]['created']),
                             'checksum': checksum,
                             'checksum_type': 'SHA-512',
                             'state': 'A',
@@ -227,7 +227,7 @@ class Object:
                     if filepath in info:
                         files_in_this_version.add(filepath)
                         if checksum == info[filepath]['checksum'] and not file_handled_mapping[filepath]:
-                            info[filepath]['last_modified'] = utc_datetime_from_string(self._inventory['versions'][version_num]['created'])
+                            info[filepath]['last_modified'] = utc_datetime_from_string_custom(self._inventory['versions'][version_num]['created'])
             #if there are any files in the head version, that aren't in this version, mark that we shouldn't update their time anymore
             for filepath in file_handled_mapping:
                 if filepath not in files_in_this_version:
@@ -236,11 +236,11 @@ class Object:
 
     @property
     def created(self):
-        return utc_datetime_from_string(self._inventory['versions']['v1']['created'])
+        return utc_datetime_from_string_custom(self._inventory['versions']['v1']['created'])
 
     @property
     def last_modified(self):
-        return utc_datetime_from_string(self._inventory['versions'][self.head_version]['created'])
+        return utc_datetime_from_string_custom(self._inventory['versions'][self.head_version]['created'])
 
     def get_path_to_file(self, filename, version=None):
         if not version:

--- a/tests/test_ocfl.py
+++ b/tests/test_ocfl.py
@@ -105,15 +105,18 @@ class TestOcfl(unittest.TestCase):
                 self.assertEqual(function('2021-03-23T10:20:30Z'), datetime(2021, 3, 23, 10, 20, 30, tzinfo=timezone.utc))
                 self.assertEqual(function('2021-03-23T10:20:30.000Z'), datetime(2021, 3, 23, 10, 20, 30, tzinfo=timezone.utc))
                 self.assertEqual(function('2020-11-25T20:30:43.7Z'), datetime(2020, 11, 25, 20, 30, 43, 700000, tzinfo=timezone.utc))
+                self.assertEqual(function('2020-11-25T22:30:43.7+02:00'), datetime(2020, 11, 25, 20, 30, 43, 700000, tzinfo=timezone.utc))
+                self.assertEqual(function('2020-11-25T22:30:43+02:00'), datetime(2020, 11, 25, 20, 30, 43, 0, tzinfo=timezone.utc))
+                self.assertEqual(function('2020-11-25T18:30:43-02:00'), datetime(2020, 11, 25, 20, 30, 43, 0, tzinfo=timezone.utc))
                 self.assertEqual(function('2020-11-25T20:30:43.73Z'), datetime(2020, 11, 25, 20, 30, 43, 730000, tzinfo=timezone.utc))
-                self.assertEqual(function('2020-11-25T20:30:43.737Z'), datetime(2020, 11, 25, 20, 30, 43, 737000, tzinfo=timezone.utc))
-                self.assertEqual(function('2020-11-25T20:30:43.73776Z'), datetime(2020, 11, 25, 20, 30, 43, 737760, tzinfo=timezone.utc)) #common in ocfl
-                self.assertEqual(function('2021-03-23T10:20:30.522328Z'), datetime(2021, 3, 23, 10, 20, 30, 522328, tzinfo=timezone.utc))
+                self.assertEqual(function('2020-11-25T20:30:43.737Z'), datetime(2020, 11, 25, 20, 30, 43, 737000, tzinfo=timezone.utc)) #common in fedora history
+                self.assertEqual(function('2020-11-25T20:30:43.73776Z'), datetime(2020, 11, 25, 20, 30, 43, 737760, tzinfo=timezone.utc)) #in ocfl objs, but maybe more rare than next one
+                self.assertEqual(function('2021-03-23T10:20:30.522328Z'), datetime(2021, 3, 23, 10, 20, 30, 522328, tzinfo=timezone.utc)) #common in new ocfl objs
                 with self.assertRaises(ocfl.DateTimeError):
                     function('2021-03-23T06:20:30')
         #now time the functions
         print('datetime parsing speeds:')
-        for date_string in ['2021-03-23T06:20:30.522328-04:00', '2021-03-23T06:20:30.52232-04:00', '2020-11-25T20:30:43.73776Z']:
+        for date_string in ['2021-03-23T06:20:30.522328-04:00', '2021-03-23T06:20:30.52232-04:00', '2020-11-25T20:30:43.737Z', '2020-11-25T20:30:43.73776Z', '2020-11-25T20:30:43.737760Z']:
             print(date_string)
             speed = timeit.timeit(f'ocfl.utc_datetime_from_string("{date_string}")', number=10000, setup='from bdrocfl import ocfl')
             print(f'  utc_datetime_from_string: {speed}')

--- a/tests/test_ocfl.py
+++ b/tests/test_ocfl.py
@@ -96,34 +96,28 @@ class TestOcfl(unittest.TestCase):
 
     def test_datetime_from_string(self):
         self.maxDiff = None
-        for function in [ocfl.utc_datetime_from_string, ocfl.utc_datetime_from_string_isoformat, ocfl.utc_datetime_from_string_custom]:
-            with self.subTest(function=function):
-                dt = function('2021-03-23T06:20:30.522328-04:00')
-                self.assertEqual(dt, datetime(2021, 3, 23, 10, 20, 30, 522328, tzinfo=timezone.utc))
-                dt = function('2021-03-23T14:20:30.522328+04:00')
-                self.assertEqual(dt, datetime(2021, 3, 23, 10, 20, 30, 522328, tzinfo=timezone.utc))
-                self.assertEqual(function('2021-03-23T10:20:30Z'), datetime(2021, 3, 23, 10, 20, 30, tzinfo=timezone.utc))
-                self.assertEqual(function('2021-03-23T10:20:30.000Z'), datetime(2021, 3, 23, 10, 20, 30, tzinfo=timezone.utc))
-                self.assertEqual(function('2020-11-25T20:30:43.7Z'), datetime(2020, 11, 25, 20, 30, 43, 700000, tzinfo=timezone.utc))
-                self.assertEqual(function('2020-11-25T22:30:43.7+02:00'), datetime(2020, 11, 25, 20, 30, 43, 700000, tzinfo=timezone.utc))
-                self.assertEqual(function('2020-11-25T22:30:43+02:00'), datetime(2020, 11, 25, 20, 30, 43, 0, tzinfo=timezone.utc))
-                self.assertEqual(function('2020-11-25T18:30:43-02:00'), datetime(2020, 11, 25, 20, 30, 43, 0, tzinfo=timezone.utc))
-                self.assertEqual(function('2020-11-25T20:30:43.73Z'), datetime(2020, 11, 25, 20, 30, 43, 730000, tzinfo=timezone.utc))
-                self.assertEqual(function('2020-11-25T20:30:43.737Z'), datetime(2020, 11, 25, 20, 30, 43, 737000, tzinfo=timezone.utc)) #common in fedora history
-                self.assertEqual(function('2020-11-25T20:30:43.73776Z'), datetime(2020, 11, 25, 20, 30, 43, 737760, tzinfo=timezone.utc)) #in ocfl objs, but maybe more rare than next one
-                self.assertEqual(function('2021-03-23T10:20:30.522328Z'), datetime(2021, 3, 23, 10, 20, 30, 522328, tzinfo=timezone.utc)) #common in new ocfl objs
-                with self.assertRaises(ocfl.DateTimeError):
-                    function('2021-03-23T06:20:30')
+        dt = ocfl.utc_datetime_from_string('2021-03-23T06:20:30.522328-04:00')
+        self.assertEqual(dt, datetime(2021, 3, 23, 10, 20, 30, 522328, tzinfo=timezone.utc))
+        dt = ocfl.utc_datetime_from_string('2021-03-23T14:20:30.522328+04:00')
+        self.assertEqual(dt, datetime(2021, 3, 23, 10, 20, 30, 522328, tzinfo=timezone.utc))
+        self.assertEqual(ocfl.utc_datetime_from_string('2021-03-23T10:20:30Z'), datetime(2021, 3, 23, 10, 20, 30, tzinfo=timezone.utc))
+        self.assertEqual(ocfl.utc_datetime_from_string('2021-03-23T10:20:30.000Z'), datetime(2021, 3, 23, 10, 20, 30, tzinfo=timezone.utc))
+        self.assertEqual(ocfl.utc_datetime_from_string('2020-11-25T20:30:43.7Z'), datetime(2020, 11, 25, 20, 30, 43, 700000, tzinfo=timezone.utc))
+        self.assertEqual(ocfl.utc_datetime_from_string('2020-11-25T22:30:43.7+02:00'), datetime(2020, 11, 25, 20, 30, 43, 700000, tzinfo=timezone.utc))
+        self.assertEqual(ocfl.utc_datetime_from_string('2020-11-25T22:30:43+02:00'), datetime(2020, 11, 25, 20, 30, 43, 0, tzinfo=timezone.utc))
+        self.assertEqual(ocfl.utc_datetime_from_string('2020-11-25T18:30:43-02:00'), datetime(2020, 11, 25, 20, 30, 43, 0, tzinfo=timezone.utc))
+        self.assertEqual(ocfl.utc_datetime_from_string('2020-11-25T20:30:43.73Z'), datetime(2020, 11, 25, 20, 30, 43, 730000, tzinfo=timezone.utc))
+        self.assertEqual(ocfl.utc_datetime_from_string('2020-11-25T20:30:43.737Z'), datetime(2020, 11, 25, 20, 30, 43, 737000, tzinfo=timezone.utc)) #common in fedora history
+        self.assertEqual(ocfl.utc_datetime_from_string('2020-11-25T20:30:43.73776Z'), datetime(2020, 11, 25, 20, 30, 43, 737760, tzinfo=timezone.utc)) #in ocfl objs, but maybe more rare than next one
+        self.assertEqual(ocfl.utc_datetime_from_string('2021-03-23T10:20:30.522328Z'), datetime(2021, 3, 23, 10, 20, 30, 522328, tzinfo=timezone.utc)) #common in new ocfl objs
+        with self.assertRaises(ocfl.DateTimeError):
+            ocfl.utc_datetime_from_string('2021-03-23T06:20:30')
         #now time the functions
         print('datetime parsing speeds:')
         for date_string in ['2021-03-23T06:20:30.522328-04:00', '2021-03-23T06:20:30.52232-04:00', '2020-11-25T20:30:43.737Z', '2020-11-25T20:30:43.73776Z', '2020-11-25T20:30:43.737760Z']:
             print(date_string)
             speed = timeit.timeit(f'ocfl.utc_datetime_from_string("{date_string}")', number=10000, setup='from bdrocfl import ocfl')
             print(f'  utc_datetime_from_string: {speed}')
-            speed = timeit.timeit(f'ocfl.utc_datetime_from_string_isoformat("{date_string}")', number=10000, setup='from bdrocfl import ocfl')
-            print(f'  utc_datetime_from_string_isoformat: {speed}')
-            speed = timeit.timeit(f'ocfl.utc_datetime_from_string_custom("{date_string}")', number=10000, setup='from bdrocfl import ocfl')
-            print(f'  utc_datetime_from_string_custom: {speed}')
 
     def test_reversed_version_numbers(self):
         inventory = {'versions': {'v1': None, 'v10': None, 'v2': None, 'v3': None, 'v4': None, 'v5': None, 'v6': None, 'v7': None, 'v8': None, 'v9': None}}


### PR DESCRIPTION
Using strptime is slow. datetime.fromisoformat() is fast, but limited in
what it can parse. This commit adds a new function that tries to use
isoformat, and falls back on strptime if needed, and another new
function that uses more custom code to parse timestamps.

All 3 functions pass the tests, and here are the timeit values:

2021-03-23T06:20:30.522328-04:00
  utc_datetime_from_string: 0.16827842600469012
  utc_datetime_from_string_isoformat: 0.003353077991050668
  utc_datetime_from_string_custom: 0.06806577798852231
2021-03-23T06:20:30.52232-04:00
  utc_datetime_from_string: 0.15312162099871784
  utc_datetime_from_string_isoformat: 0.1722432920068968
  utc_datetime_from_string_custom: 0.06483625598775689
2020-11-25T20:30:43.73776Z
  utc_datetime_from_string: 0.10550696100108325
  utc_datetime_from_string_isoformat: 0.1303601539984811
  utc_datetime_from_string_custom: 0.03477333100454416

Notes:
  - strptime is consistently slow
  - isoformat is very fast, but has to fall back to a slow strptime
  - the custom function is consistently much faster than strptime