### PR TITLE
Add code for walking the BDR repo

### DIFF
--- a/src/bdrocfl/ocfl.py
+++ b/src/bdrocfl/ocfl.py
@@ -317,3 +317,29 @@ class Object:
             if info['state'] == 'A' or include_deleted:
                 files_info[filename] = {field: value for field, value in info.items() if field in fields}
         return files_info
+
+
+def walk_repo(storage_root, top_ntuple_segment=None):
+    '''generate all the pids in a repo
+    root/
+        extensions/
+        1b5/
+            64f/
+                1ff/
+                    testsuite%3aabcd1234/'''
+    with os.scandir(storage_root) as root_it:
+        for root_entry in root_it:
+            if root_entry.is_dir() and root_entry.name != 'extensions':
+                if top_ntuple_segment and root_entry.name != top_ntuple_segment:
+                    continue
+                root_entry_path = os.path.join(storage_root, root_entry.name)
+                with os.scandir(root_entry_path) as next_it:
+                    for next_entry in next_it:
+                        next_entry_path = os.path.join(root_entry_path, next_entry.name)
+                        with os.scandir(next_entry_path) as another_it:
+                            for another_entry in another_it:
+                                another_entry_path = os.path.join(next_entry_path, another_entry.name)
+                                #now we're down to scanning object root directories
+                                with os.scandir(another_entry_path) as object_root_it:
+                                    for object_entry in object_root_it:
+                                        yield object_entry.name.replace('%3a', ':')

--- a/tests/test_ocfl.py
+++ b/tests/test_ocfl.py
@@ -316,3 +316,18 @@ class TestTestUtils(unittest.TestCase):
             inventory_data = f.read().decode('utf8')
         inventory = json.loads(inventory_data)
         self.assertEqual(inventory['versions'][inventory['head']]['state'], {})
+
+
+class TestWalkRepo(unittest.TestCase):
+
+    def test_1(self):
+        extensions_path = os.path.join(OCFL_ROOT, 'extensions')
+        os.mkdir(extensions_path)
+        pids = ['testsuite:abcd1234', 'testsuite:efgh5678']
+        for p in pids:
+            test_utils.create_object(OCFL_ROOT, p)
+        listed_pids = sorted(list(ocfl.walk_repo(OCFL_ROOT)))
+        self.assertEqual(listed_pids, pids)
+        listed_pids = sorted(list(ocfl.walk_repo(OCFL_ROOT, top_ntuple_segment='80a')))
+        self.assertEqual(listed_pids, ['testsuite:efgh5678'])
+        os.rmdir(extensions_path)


### PR DESCRIPTION
Has an option for only walking one top-level section of the repo. If you
pass that option in, it will only walk the objects in that section (eg.
everything in the '000' top-level directory). There may be a better way
to name this...